### PR TITLE
All remaining perf improvments super and single

### DIFF
--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -143,6 +143,20 @@ fn bench(c: &mut Criterion) {
     }
 
     for name in &[
+        "a_node4_opaque_evt65536",
+        "a_node8_opaque_evt65536",
+        "a_node16_opaque_evt65536",
+        "a_node32_opaque_evt65536",
+    ] {
+        bench_dot_file(
+            c,
+            "bench_section_size_evt65536_interleave",
+            name,
+            ConsensusMode::Single,
+        );
+    }
+
+    for name in &[
         "PublicIdname754598-001",
         "PublicIdname754598-002",
         "PublicIdname754598-003",

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -129,6 +129,18 @@ fn bench(c: &mut Criterion) {
     }
 
     for name in &[
+        "a_node4_opaque_evt8192",
+        "a_node8_opaque_evt8192",
+    ] {
+        bench_dot_file(
+            c,
+            "bench_section_size_evt8192_interleave",
+            name,
+            ConsensusMode::Single,
+        );
+    }
+
+    for name in &[
         "PublicIdname754598-001",
         "PublicIdname754598-002",
         "PublicIdname754598-003",

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -131,6 +131,8 @@ fn bench(c: &mut Criterion) {
     for name in &[
         "a_node4_opaque_evt8192",
         "a_node8_opaque_evt8192",
+        "a_node16_opaque_evt8192",
+        "a_node32_opaque_evt8192",
     ] {
         bench_dot_file(
             c,

--- a/dot_gen/src/main.rs
+++ b/dot_gen/src/main.rs
@@ -467,6 +467,28 @@ fn add_bench_section_size(scenarios: &mut Scenarios) {
             &format!("{}_interleave", opaque_to_add),
         );
     }
+
+    for genesis_size in &[4, 8, 16, 32] {
+        let opaque_to_add = 8192;
+        add_bench_scalability_common(
+            scenarios,
+            ScheduleOptions {
+                genesis_size: *genesis_size,
+                opaque_to_add,
+                // 1 gossip event every 10 steps in one peer in the network
+                prob_gossip: 0.1 / (*genesis_size as f64 * 8.0),
+                // 1 opaque event per 10 steps
+                prob_opaque: 0.1,
+                // Events will be seen within 2 gossip events
+                max_observation_delay: 20 * 8,
+                // For speed only check consistency at the end
+                intermediate_consistency_checks: false,
+                ..Default::default()
+            },
+            ConsensusMode::Single,
+            &format!("{}_interleave", opaque_to_add),
+        );
+    }
 }
 
 fn add_bench_scalability_common(

--- a/dot_gen/src/main.rs
+++ b/dot_gen/src/main.rs
@@ -489,6 +489,28 @@ fn add_bench_section_size(scenarios: &mut Scenarios) {
             &format!("{}_interleave", opaque_to_add),
         );
     }
+
+    for genesis_size in &[4, 8, 16, 32] {
+        let opaque_to_add = 65536;
+        add_bench_scalability_common(
+            scenarios,
+            ScheduleOptions {
+                genesis_size: *genesis_size,
+                opaque_to_add,
+                // 1 gossip event every 10 steps in one peer in the network
+                prob_gossip: 0.1 / (*genesis_size as f64 * 64.0),
+                // 1 opaque event per 10 steps
+                prob_opaque: 0.1,
+                // Events will be seen within 2 gossip events
+                max_observation_delay: 20 * 64,
+                // For speed only check consistency at the end
+                intermediate_consistency_checks: false,
+                ..Default::default()
+            },
+            ConsensusMode::Single,
+            &format!("{}_interleave", opaque_to_add),
+        );
+    }
 }
 
 fn add_bench_scalability_common(

--- a/src/dev_utils/dot_parser.rs
+++ b/src/dev_utils/dot_parser.rs
@@ -33,7 +33,7 @@ use crate::observation::{
 };
 use crate::peer_list::{PeerIndex, PeerIndexMap, PeerIndexSet, PeerList, PeerState};
 use crate::round_hash::RoundHash;
-use fnv::{FnvHashMap, FnvHashSet};
+use fnv::FnvHashMap; //{FnvHashMap, FnvHashSet};
 use itertools::Itertools;
 use pom::char_class::{alphanum, digit, hex_digit, multispace, space};
 use pom::parser::*;
@@ -901,7 +901,7 @@ fn convert_to_meta_election(
                     )
                 })
                 .collect_vec();
-            let contents: FnvHashSet<_> = indices
+            let contents: BTreeSet<_> = indices
                 .iter()
                 .filter_map(|index| meta_events.get(index))
                 .flat_map(|meta_event| &meta_event.interesting_content)

--- a/src/dev_utils/dot_parser.rs
+++ b/src/dev_utils/dot_parser.rs
@@ -50,6 +50,7 @@ use std::str::FromStr;
 pub const HEX_DIGITS_PER_BYTE: usize = 2;
 
 type ObservationMap = Vec<(ObservationKey, Observation<Transaction, PeerId>)>;
+type PeerParsedEvent = BTreeMap<i32, (String, ParsedEvent)>;
 
 fn newline() -> Parser<u8, ()> {
     (seq(b"\n") | seq(b"\r\n")).discard()
@@ -998,11 +999,7 @@ fn create_events(
     let mut event_indices = BTreeMap::new();
 
     let graph = std::mem::replace(graph, BTreeMap::new());
-
-    let mut graph: BTreeMap<(Option<PeerIndex>, String), ParsedEvent> = graph
-        .into_iter()
-        .map(|(name, evt)| ((peer_list.get_index(&evt.creator), name.clone()), evt))
-        .collect();
+    let mut graph = in_peer_order(graph, peer_list);
 
     while !graph.is_empty() {
         let (ev_id, next_parsed_event) = next_topological_event(&mut graph, &event_indices);
@@ -1054,29 +1051,75 @@ fn get_event_by_id<'a>(
     indices.get(id).cloned().and_then(|index| graph.get(index))
 }
 
+fn in_peer_order(
+    graph: BTreeMap<String, ParsedEvent>,
+    peer_list: &PeerList<PeerId>,
+) -> BTreeMap<(Option<PeerIndex>, String), PeerParsedEvent> {
+    type Key = (Option<PeerIndex>, (String, i32));
+    let graph: BTreeMap<Key, (String, ParsedEvent)> = graph
+        .into_iter()
+        .map(|(name, evt)| {
+            let parsed_values = name
+                .rsplit('_')
+                .next()
+                .map(|index| (index.len(), index.parse::<i32>()));
+
+            let (index_len, index) = unwrap!(parsed_values, "{}", name);
+            let index = unwrap!(index, "{}", name);
+
+            let prefix = name[0..(name.len() - index_len)].to_string();
+            ((prefix, index), (name.clone(), evt))
+        })
+        .map(|(name, evt)| ((peer_list.get_index(&evt.1.creator), name), evt))
+        .collect();
+
+    let mut new_graph = BTreeMap::new();
+    for ((peer_index, (prefix, index)), event) in graph.into_iter() {
+        let _ = new_graph
+            .entry((peer_index, prefix))
+            .or_insert_with(BTreeMap::new)
+            .insert(index, event);
+    }
+    new_graph
+}
+
 fn next_topological_event(
-    graph: &mut BTreeMap<(Option<PeerIndex>, String), ParsedEvent>,
+    graph: &mut BTreeMap<(Option<PeerIndex>, String), PeerParsedEvent>,
     indices: &BTreeMap<String, EventIndex>,
 ) -> (String, ParsedEvent) {
-    let next_key = unwrap!(graph
-        .iter()
-        .filter(|&(_, ref event)| event
-            .self_parent
-            .as_ref()
-            .map(|ev_id| indices.contains_key(ev_id))
-            .unwrap_or(true)
-            && event
-                .other_parent
-                .as_ref()
-                .map(|ev_id| indices.contains_key(ev_id))
-                .unwrap_or(true))
-        .map(|(key, _)| key)
-        .next())
-    .clone();
-    let ev = unwrap!(graph.remove(&next_key));
+    let next_event = graph
+        .values_mut()
+        .filter_map(|peer_events| {
+            let index_with_parents = peer_events
+                .iter()
+                .next()
+                .filter(|(_, (_, event))| {
+                    let self_parent_found = event
+                        .self_parent
+                        .as_ref()
+                        .map(|ev_id| indices.contains_key(ev_id))
+                        .unwrap_or(true);
+                    let other_parent_found = event
+                        .other_parent
+                        .as_ref()
+                        .map(|ev_id| indices.contains_key(ev_id))
+                        .unwrap_or(true);
 
-    let (_, next_key) = next_key;
-    (next_key, ev)
+                    self_parent_found && other_parent_found
+                })
+                .map(|(index, _)| *index);
+
+            index_with_parents.map(|index| unwrap!(peer_events.remove(&index)))
+        })
+        .next();
+
+    let empty_key = graph
+        .iter()
+        .find(|(_, peer_events)| peer_events.is_empty())
+        .map(|(key, _)| key.clone());
+    let _ = empty_key.map(|key| unwrap!(graph.remove(&key)));
+
+    unwrap!(next_event)
 }
 
 #[cfg(all(test, feature = "dump-graphs"))]

--- a/src/dev_utils/network.rs
+++ b/src/dev_utils/network.rs
@@ -503,6 +503,10 @@ impl Network {
             }
         }
 
+        for peer_id in self.running_peers_ids() {
+            self.check_unexpected_accusations(&peer_id)?;
+        }
+
         self.check_consensus(&peers, min_observations, max_observations)?;
         self.check_blocks_signatories()
     }
@@ -569,7 +573,9 @@ impl Network {
                     self.peer_mut(&peer_id).make_votes();
                     self.handle_messages(&peer_id, step);
                     self.peer_mut(&peer_id).poll_all();
-                    self.check_unexpected_accusations(&peer_id)?;
+                    if options.intermediate_consistency_checks {
+                        self.check_unexpected_accusations(&peer_id)?;
+                    }
                 }
                 Peer::update_network_views(&mut self.peers);
                 let running_peers_ids = self.running_peers_ids();

--- a/src/dev_utils/network.rs
+++ b/src/dev_utils/network.rs
@@ -426,10 +426,8 @@ impl Network {
 
         for block_group in block_groups {
             for block in block_group {
-                if let ParsecObservation::Genesis(_) = *block.payload() {
-                    // Explicitly don't check signatories - the list of valid voters should be empty
-                    // at this point.
-                    continue;
+                if let ParsecObservation::Genesis(ref g) = *block.payload() {
+                    valid_voters = g.clone();
                 }
 
                 self.check_block_signatories(block, &valid_voters)?;
@@ -437,9 +435,7 @@ impl Network {
 
             for block in block_group {
                 match *block.payload() {
-                    ParsecObservation::Genesis(ref g) => {
-                        valid_voters = g.clone();
-                    }
+                    ParsecObservation::Genesis(_) => (),
                     ParsecObservation::Add { ref peer_id, .. } => {
                         let _ = valid_voters.insert(peer_id.clone());
                     }

--- a/src/dump_graph.rs
+++ b/src/dump_graph.rs
@@ -254,23 +254,23 @@ mod detail {
         let _ = force_symlink_dir(&*ROOT_DIR, ROOT_DIR_PREFIX.join("latest"));
     }
 
-    fn parent_pos<P: PublicId>(
-        index: usize,
-        parent: Option<IndexedEventRef<P>>,
-        positions: &BTreeMap<EventHash, usize>,
-    ) -> Option<usize> {
-        if let Some(parent_hash) = parent.map(|e| e.inner().hash()) {
-            if let Some(parent_pos) = positions.get(parent_hash) {
-                Some(*parent_pos)
-            } else if *parent_hash == EventHash::ZERO {
-                Some(index)
-            } else {
-                None
-            }
-        } else {
-            Some(index)
-        }
-    }
+    // fn parent_pos<P: PublicId>(
+    //     index: usize,
+    //     parent: Option<IndexedEventRef<P>>,
+    //     positions: &BTreeMap<EventHash, usize>,
+    // ) -> Option<usize> {
+    //     if let Some(parent_hash) = parent.map(|e| e.inner().hash()) {
+    //         if let Some(parent_pos) = positions.get(parent_hash) {
+    //             Some(*parent_pos)
+    //         } else if *parent_hash == EventHash::ZERO {
+    //             Some(index)
+    //         } else {
+    //             None
+    //         }
+    //     } else {
+    //         Some(index)
+    //     }
+    // }
 
     fn force_symlink_dir<P: AsRef<Path>, Q: AsRef<Path>>(src: P, dst: Q) -> io::Result<()> {
         use std::io::ErrorKind;
@@ -448,7 +448,7 @@ mod detail {
             self.writeln(format_args!("  splines=false"))?;
             self.writeln(format_args!("  rankdir=BT\n"))?;
 
-            let positions = self.calculate_positions();
+            let positions = BTreeMap::new(); //self.calculate_positions();
             for (peer_index, peer_id) in self.peer_ids {
                 self.write_subgraph(peer_index, peer_id, &positions)?;
                 self.write_other_parents(peer_index)?;
@@ -494,39 +494,39 @@ mod detail {
             self.writeln(format_args!("{}{}}}", Self::COMMENT, indent))
         }
 
-        fn calculate_positions(&self) -> BTreeMap<EventHash, usize> {
-            let mut positions = BTreeMap::new();
-            while positions.len() < self.gossip_graph.len() {
-                for event in self.gossip_graph {
-                    if !positions.contains_key(event.hash()) {
-                        let self_parent_pos = if let Some(position) = parent_pos(
-                            event.index_by_creator(),
-                            self.gossip_graph.self_parent(event),
-                            &positions,
-                        ) {
-                            position
-                        } else {
-                            continue;
-                        };
-                        let other_parent_pos = if let Some(position) = parent_pos(
-                            event.index_by_creator(),
-                            self.gossip_graph.other_parent(event),
-                            &positions,
-                        ) {
-                            position
-                        } else {
-                            continue;
-                        };
-                        let _ = positions.insert(
-                            *event.hash(),
-                            cmp::max(self_parent_pos, other_parent_pos) + 1,
-                        );
-                        break;
-                    }
-                }
-            }
-            positions
-        }
+        // fn _calculate_positions(&self) -> BTreeMap<EventHash, usize> {
+        //     let mut positions = BTreeMap::new();
+        //     while positions.len() < self.gossip_graph.len() {
+        //         for event in self.gossip_graph {
+        //             if !positions.contains_key(event.hash()) {
+        //                 let self_parent_pos = if let Some(position) = parent_pos(
+        //                     event.index_by_creator(),
+        //                     self.gossip_graph.self_parent(event),
+        //                     &positions,
+        //                 ) {
+        //                     position
+        //                 } else {
+        //                     continue;
+        //                 };
+        //                 let other_parent_pos = if let Some(position) = parent_pos(
+        //                     event.index_by_creator(),
+        //                     self.gossip_graph.other_parent(event),
+        //                     &positions,
+        //                 ) {
+        //                     position
+        //                 } else {
+        //                     continue;
+        //                 };
+        //                 let _ = positions.insert(
+        //                     *event.hash(),
+        //                     cmp::max(self_parent_pos, other_parent_pos) + 1,
+        //                 );
+        //                 break;
+        //             }
+        //         }
+        //     }
+        //     positions
+        // }
 
         fn write_subgraph(
             &mut self,

--- a/src/gossip/graph/mod.rs
+++ b/src/gossip/graph/mod.rs
@@ -112,6 +112,29 @@ impl<P: PublicId> Graph<P> {
             .and_then(|index| self.get(index))
     }
 
+    /// Returns self-parent of the given event, if any.
+    pub fn self_consensus_parent<E: AsRef<Event<P>>>(
+        &self,
+        event: E,
+    ) -> Option<IndexedEventRef<P>> {
+        let mut event = event.as_ref();
+        loop {
+            let opt_parent = event.self_parent().and_then(|index| self.get(index));
+            if let Some(parent) = opt_parent {
+                if parent.payload_key().is_none() {
+                    return opt_parent;
+                }
+                event = parent.inner();
+            } else {
+                return None;
+            }
+        }
+        // event
+        //     .as_ref()
+        //     .self_parent()
+        //     .and_then(|index| self.get(index))
+    }
+
     /// Returns other-parent of the given event, if any.
     pub fn other_parent<E: AsRef<Event<P>>>(&self, event: E) -> Option<IndexedEventRef<P>> {
         event

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -172,6 +172,11 @@ extern crate serde_derive;
 #[macro_use]
 extern crate unwrap;
 
+use std::alloc::System;
+
+#[global_allocator]
+static GLOBAL: System = System;
+
 mod block;
 mod dump_graph;
 mod error;

--- a/src/meta_voting/meta_election.rs
+++ b/src/meta_voting/meta_election.rs
@@ -314,10 +314,11 @@ impl MetaElection {
             self.meta_events.retain(|event_index, _| {
                 event_index.topological_index() >= new_consensus_start_index
             });
+            let decided_keys_lookup: FnvHashSet<_> = decided_keys.iter().collect();
             for meta_event in self.meta_events.values_mut() {
                 meta_event
                     .interesting_content
-                    .retain(|payload_key| !decided_keys.contains(payload_key));
+                    .retain(|payload_key| !decided_keys_lookup.contains(payload_key));
             }
         }
     }

--- a/src/meta_voting/meta_election.rs
+++ b/src/meta_voting/meta_election.rs
@@ -135,14 +135,12 @@ impl MetaElection {
             .map(|(peer_index, (event_indices, _))| (peer_index, &event_indices[..]))
     }
 
-    pub fn first_interesting_content_by(&self, creator: PeerIndex) -> Option<&ObservationKey> {
-        let event_index = self
-            .interesting_events
+    pub fn interesting_content_by(&self, creator: PeerIndex) -> Option<&Vec<ObservationKey>> {
+        self.interesting_events
             .get(creator)
-            .and_then(|(indices, _)| indices.first())?;
-        let meta_event = self.meta_events.get(event_index)?;
-
-        meta_event.interesting_content.first()
+            .and_then(|(indices, _)| indices.first())
+            .and_then(|event_index| self.meta_events.get(event_index))
+            .map(|meta_event| &meta_event.interesting_content)
     }
 
     pub fn is_already_interesting_content(

--- a/src/meta_voting/meta_election.rs
+++ b/src/meta_voting/meta_election.rs
@@ -41,7 +41,7 @@ pub(crate) struct MetaElection {
     pub(crate) voters: PeerIndexSet,
     // The indices of events for each peer that have a non-empty set of `interesting_content`.
     // The second element allow fast lookup for existing interesting_content.
-    pub(crate) interesting_events: PeerIndexMap<(Vec<EventIndex>, FnvHashSet<ObservationKey>)>,
+    pub(crate) interesting_events: PeerIndexMap<(Vec<EventIndex>, BTreeSet<ObservationKey>)>,
     // All events that carry a payload that hasn't yet been consensused.
     pub(crate) unconsensused_events: UnconsensusedEvents,
     // Events that carry a payload that hasn't yet been consensused and not interesting.
@@ -274,7 +274,7 @@ impl MetaElection {
         let (indices, contents) = self
             .interesting_events
             .entry(creator)
-            .or_insert_with(|| (Vec::new(), FnvHashSet::default()));
+            .or_insert_with(|| (Vec::new(), BTreeSet::default()));
         indices.push(event_index);
         contents.extend(interesting_content);
 

--- a/src/parsec.rs
+++ b/src/parsec.rs
@@ -1358,11 +1358,9 @@ impl<T: NetworkEvent, S: SecretId> Parsec<T, S> {
             .iter()
             .map(|payload_key| {
                 let votes = self
-                    .graph
-                    .iter()
+                    .unconsensused_events(Some(payload_key))
                     .map(|event| event.inner())
                     .filter(|event| voters.contains(event.creator()))
-                    .filter(|event| event.payload_key() == Some(payload_key))
                     .filter_map(|event| {
                         let (vote, key) = event.vote_and_payload_key(&self.observations)?;
                         let creator_id =

--- a/src/parsec.rs
+++ b/src/parsec.rs
@@ -861,7 +861,8 @@ impl<T: NetworkEvent, S: SecretId> Parsec<T, S> {
 
         let payloads = find_interesting_content_for_event(
             builder.event().as_ref(),
-            self.unconsensused_events(None).map(|event| event.inner()),
+            self.unconsensused_not_interesting_events(builder.event().creator())
+                .map(|event| event.inner()),
             is_already_interesting_content,
             is_interesting_payload,
             has_interesting_ancestor,
@@ -1266,6 +1267,15 @@ impl<T: NetworkEvent, S: SecretId> Parsec<T, S> {
     ) -> impl Iterator<Item = IndexedEventRef<S::PublicId>> {
         self.meta_election
             .unconsensused_events(filter_key)
+            .filter_map(move |index| self.get_known_event(index).ok())
+    }
+
+    fn unconsensused_not_interesting_events(
+        &self,
+        creator: PeerIndex,
+    ) -> impl Iterator<Item = IndexedEventRef<S::PublicId>> {
+        self.meta_election
+            .unconsensused_not_interesting_events(creator)
             .filter_map(move |index| self.get_known_event(index).ok())
     }
 

--- a/src/parsec.rs
+++ b/src/parsec.rs
@@ -653,6 +653,14 @@ impl<T: NetworkEvent, S: SecretId> Parsec<T, S> {
             return Ok(PostProcessAction::Continue);
         }
 
+        {
+            let event = get_known_event(self.our_pub_id(), &self.graph, event_index)?;
+            if event.payload_key().is_some() {
+                // Only add meta events for non obaservations: Requesting/Request/Response
+                return Ok(PostProcessAction::Continue);
+            }
+        }
+
         self.create_meta_event(event_index)?;
 
         let payload_keys = self.compute_consensus(event_index);
@@ -981,17 +989,20 @@ impl<T: NetworkEvent, S: SecretId> Parsec<T, S> {
 
     fn is_descendant_of_observer(&self, event: IndexedEventRef<S::PublicId>) -> bool {
         self.graph
-            .self_parent(event)
+            .self_consensus_parent(event)
             .and_then(|self_parent| self.meta_election.meta_event(self_parent.event_index()))
             .map(|meta_parent| meta_parent.is_observer() || meta_parent.has_ancestor_observer())
             .unwrap_or(false)
     }
 
     fn set_meta_votes(&self, builder: &mut MetaEventBuilder<S::PublicId>) -> Result<()> {
-        let parent_meta_votes = builder
-            .event()
-            .self_parent()
-            .and_then(|parent_hash| self.meta_election.populated_meta_votes(parent_hash));
+        let parent_meta_votes =
+            self.graph
+                .self_consensus_parent(builder.event())
+                .and_then(|parent| {
+                    self.meta_election
+                        .populated_meta_votes(parent.event_index())
+                });
 
         if parent_meta_votes.is_none() && !builder.is_observer() {
             // No meta votes to set for this event

--- a/src/parsec_helpers.rs
+++ b/src/parsec_helpers.rs
@@ -16,7 +16,7 @@ use std::usize;
 pub(crate) fn find_interesting_content_for_event<'a, E>(
     builder_event: &E,
     unconsensused_events: impl Iterator<Item = &'a E>,
-    is_already_interesting_content: impl Fn(&ObservationKey) -> bool,
+    _is_already_interesting_content: impl Fn(&ObservationKey) -> bool,
     is_interesting_payload: impl Fn(&ObservationKey) -> bool,
     has_interesting_ancestor: impl Fn(&ObservationKey) -> bool,
 ) -> Vec<ObservationKey>
@@ -30,7 +30,7 @@ where
         .filter_map(|event| {
             event
                 .payload_key()
-                .filter(|payload_key| !is_already_interesting_content(payload_key))
+                //.filter(|payload_key| !is_already_interesting_content(payload_key))
                 .map(|payload_key| {
                     (
                         event,
@@ -312,19 +312,19 @@ mod tests {
             });
         }
 
-        #[test]
-        /// Filter out already interesting payloads
-        fn all_payloads_already_interesting() {
-            test_find_interesting_content_for_event(TestSimpleData {
-                events: Events::new_basic_setup().with_builder_event_sees_other(),
-                payload_properties: PayloadProperties {
-                    is_already_interesting_content: true,
-                    is_interesting_payload: true,
-                    has_interesting_ancestor: false,
-                },
-                expected_payloads: vec![],
-            });
-        }
+        // #[test]
+        // /// Filter out already interesting payloads
+        // fn all_payloads_already_interesting() {
+        //     test_find_interesting_content_for_event(TestSimpleData {
+        //         events: Events::new_basic_setup().with_builder_event_sees_other(),
+        //         payload_properties: PayloadProperties {
+        //             is_already_interesting_content: true,
+        //             is_interesting_payload: true,
+        //             has_interesting_ancestor: false,
+        //         },
+        //         expected_payloads: vec![],
+        //     });
+        // }
 
         #[test]
         /// Basic case where we found no interesting payloads


### PR DESCRIPTION
This is a work in progress, most commits are in a reasonable state, but a couple of shortcuts exists.
(i.e we stop having position in dump-graphs as it is not efficient enough to handle 65'000 events, but need to be fixed or used as an option before a proper PR is raised.)

This contain 2 important changes:
 - All interesting content is consensused at once if the MetaEvent is decided. The implementation use a loop to simulate successive rounds so the vote count is correct at each round.

- Skip Observation as consensus point: This is a different view of the bundling scheme allowing to take  most of the benefit of the bundling without changing the API, and that also apply for SuperMajority. The idea is if we bundled, all these observation would be a single observation event. If we take the additional step of saying Requesting/Request/Response events behave as if they contain all the peer observations before them until the previous Requesting/Request/Response, we can now process consensus only on Requesting/Request/Response and get a similar result => Coupled with additional efficiency fixes with large number of events we can get the 65'000 event case running in a comparable time as with bundling without change in API, and also apply for supermajority.

